### PR TITLE
Add a derived data set to compute churn

### DIFF
--- a/src/main/scala/DerivedStream.scala
+++ b/src/main/scala/DerivedStream.scala
@@ -161,8 +161,7 @@ object DerivedStream {
           Some(options.getOrElse('fromDate, to), ExecutiveStream)
 
         case "Churn" =>
-          // FIXME remove 'auorora...' from the prefix.
-          val churn = Churn("telemetry/4/main/Firefox/aurora/42.0a2/20150920004018")
+          val churn = Churn("telemetry/4/main/Firefox")
           Some(options.getOrElse('fromDate, to), churn)
 
         case "e10s-enabled-aurora" =>

--- a/src/main/scala/DerivedStream.scala
+++ b/src/main/scala/DerivedStream.scala
@@ -161,8 +161,8 @@ object DerivedStream {
           Some(options.getOrElse('fromDate, to), ExecutiveStream)
 
         case "Churn" =>
-          // FIXME
-          val churn = Churn("telemetry/4/main/Firefox/aurora/42.0a2")
+          // FIXME remove 'auorora...' from the prefix.
+          val churn = Churn("telemetry/4/main/Firefox/aurora/42.0a2/20150920004018")
           Some(options.getOrElse('fromDate, to), churn)
 
         case "e10s-enabled-aurora" =>

--- a/src/main/scala/DerivedStream.scala
+++ b/src/main/scala/DerivedStream.scala
@@ -16,7 +16,7 @@ import org.json4s._
 import org.json4s.jackson.JsonMethods._
 import scala.collection.JavaConverters._
 import scala.io.Source
-import telemetry.streams.{E10sExperiment, ExecutiveStream}
+import telemetry.streams.{E10sExperiment, ExecutiveStream, Churn}
 
 case class ObjectSummary(key: String, size: Long) // S3ObjectSummary can't be serialized
 
@@ -159,6 +159,11 @@ object DerivedStream {
       (from, ds) <- stream match {
         case "ExecutiveStream" =>
           Some(options.getOrElse('fromDate, to), ExecutiveStream)
+
+        case "Churn" =>
+          // FIXME
+          val churn = Churn("telemetry/4/main/Firefox/aurora/42.0a2")
+          Some(options.getOrElse('fromDate, to), churn)
 
         case "e10s-enabled-aurora" =>
           val from = options.getOrElse('fromDate, "20151022")

--- a/src/main/scala/streams/Churn.scala
+++ b/src/main/scala/streams/Churn.scala
@@ -50,6 +50,7 @@ case class Churn(prefix: String) extends SimpleDerivedStream{
   }
   
   def enumHistogramToCount(h: JValue): Option[Long] = {
+    // FIXME
     Some(5)
   }
 

--- a/src/main/scala/streams/Churn.scala
+++ b/src/main/scala/streams/Churn.scala
@@ -98,7 +98,7 @@ case class Churn(prefix: String) extends SimpleDerivedStream{
       .set("clientId", fields.getOrElse("clientId", None) match {
              case x: String => x
              case _ => {
-               println("skip: no clientid")
+               // Skip: no client id
                return None
              }
            })
@@ -106,7 +106,7 @@ case class Churn(prefix: String) extends SimpleDerivedStream{
              case x: Long => x
              case x: Double => x.toLong
              case _ => {
-               println("skip: no sampleid")
+               // Skip: no sample id
                return None
              }
            })
@@ -129,7 +129,7 @@ case class Churn(prefix: String) extends SimpleDerivedStream{
       .set("submissionDate", fields.getOrElse("submissionDate", None) match {
              case x: String => x
              case _ => {
-               println("skip: no subdate")
+               // Skip: no submission date
                return None
              }
            })
@@ -137,22 +137,13 @@ case class Churn(prefix: String) extends SimpleDerivedStream{
              case JNothing => null
              case x: JInt => x.num.toLong
              case _ => {
-               println("profile creation date was not an int")
+               // Profile creation date was not an int
                null
              }
       })
-      .set("syncConfigured", weaveConfigured match {
-             case Some(x) => x
-             case _ => null
-           })
-      .set("syncCountDesktop", weaveDesktop match {
-             case Some(x) => x
-             case _ => null
-           })
-      .set("syncCountMobile", weaveMobile match {
-             case Some(x) => x
-             case _ => null
-           })
+      .set("syncConfigured", weaveConfigured.getOrElse(null))
+      .set("syncCountDesktop", weaveDesktop.getOrElse(null))
+      .set("syncCountMobile", weaveMobile.getOrElse(null))
       .build
     Some(root)
   }

--- a/src/main/scala/streams/Churn.scala
+++ b/src/main/scala/streams/Churn.scala
@@ -44,13 +44,11 @@ case class Churn(prefix: String) extends SimpleDerivedStream{
   // Given histogram h, return true if it has a value in the "true" bucket,
   // or false if it has a value in the "false" bucket, or None otherwise.
   def booleanHistogramToBoolean(h: JValue): Option[Boolean] = {
-    var result: Option[Boolean] = None
-    if (gtZero(h \ "values" \ "1")) {
-      result = Some(true)
-    } else if (gtZero(h \ "values" \ "0")) {
-      result = Some(false)
+    (gtZero(h \ "values" \ "1"), gtZero(h \ "values" \ "0")) match {
+      case (true, _) => Some(true)
+      case (_, true) => Some(false)
+      case _ => None
     }
-    result
   }
   
   def toInt(s: String): Option[Int] = {
@@ -82,7 +80,6 @@ case class Churn(prefix: String) extends SimpleDerivedStream{
         }
       }
       case _ => {
-//        println("Unexpected format for enum histogram")
         None
       }
     }
@@ -157,7 +154,6 @@ case class Churn(prefix: String) extends SimpleDerivedStream{
              case _ => null
            })
       .build
-//    println("Matched one record")
     Some(root)
   }
 }

--- a/src/main/scala/streams/Churn.scala
+++ b/src/main/scala/streams/Churn.scala
@@ -1,0 +1,112 @@
+package telemetry.streams
+
+import awscala._
+import awscala.s3._
+import org.apache.avro.{Schema, SchemaBuilder}
+import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder}
+import org.json4s.jackson.JsonMethods._
+import scala.collection.JavaConverters._
+import telemetry.SimpleDerivedStream
+import telemetry.heka.{HekaFrame, Message}
+import org.json4s.JsonAST.{JValue, JNothing}
+
+case class Churn(prefix: String) extends SimpleDerivedStream{
+  override def filterPrefix: String = prefix
+  override def streamName: String = "telemetry"
+  
+  override def buildSchema: Schema = {
+    SchemaBuilder
+      .record("System").fields
+      .name("clientId").`type`().stringType().noDefault()
+      .name("sampleId").`type`().intType().noDefault()
+      .name("channel").`type`().stringType().noDefault() // appUpdateChannel
+      .name("normalizedChannel").`type`().stringType().noDefault() // normalizedChannel
+      .name("country").`type`().stringType().noDefault() // geoCountry
+      .name("profileCreationDate").`type`().intType().noDefault() // environment/profile/creationDate
+      .name("submissionDate").`type`().stringType().noDefault()
+      // See bug 1232050
+      .name("syncConfigured").`type`().booleanType().noDefault() // WEAVE_CONFIGURED
+//      .name("syncCountDesktop").`type`().intType().noDefault() // WEAVE_DEVICE_COUNT_DESKTOP
+//      .name("syncCountMobile").`type`().intType().noDefault() // WEAVE_DEVICE_COUNT_MOBILE
+      
+      .name("version").`type`().stringType().noDefault() // appVersion
+      .endRecord
+  }
+
+  def booleanHistogramToBoolean(h: JValue): Option[Boolean] = {
+    if (h == JNothing) {
+      return None
+    }
+    var one = h \ "1"
+    if (one != JNothing && one.asInstanceOf[Int] > 0) {
+      return Some(true)
+    }
+    var zero = h \ "0"
+    if (zero != JNothing && zero.asInstanceOf[Int] > 0) {
+      return Some(false)
+    }
+    
+    return None
+  }
+  
+  def enumHistogramToCount(h: JValue): Option[Long] = {
+    Some(5)
+  }
+
+  override def buildRecord(message: Message, schema: Schema): Option[GenericRecord] ={
+    val fields = HekaFrame.fields(message)
+    val profile = parse(fields.getOrElse("environment.profile", "{}").asInstanceOf[String])
+    val histograms = parse(fields.getOrElse("payload.histograms", "{}").asInstanceOf[String])
+    
+    val weaveConfigured = booleanHistogramToBoolean(histograms \ "WEAVE_CONFIGURED")
+//    val weaveDesktop = enumHistogramToCount(histograms \ "WEAVE_DEVICE_COUNT_DESKTOP")
+//    val weaveMobile = enumHistogramToCount(histograms \ "WEAVE_DEVICE_COUNT_MOBILE")
+
+    val root = new GenericRecordBuilder(schema)
+      .set("clientId", fields.getOrElse("clientId", None) match {
+             case x: String => x
+             case _ => return None
+           })
+      .set("sampleId", fields.getOrElse("sampleId", None) match {
+             case x: Long => x
+             case _ => return None
+           })
+      .set("channel", fields.getOrElse("appUpdateChannel", None) match {
+             case x: String => x
+             case _ => ""
+           })
+      .set("normalizedChannel", fields.getOrElse("normalizedChannel", None) match {
+             case x: String => x
+             case _ => ""
+           })
+      .set("country", fields.getOrElse("geoCountry", None) match {
+             case x: String => x
+             case _ => ""
+           })
+      .set("version", fields.getOrElse("appVersion", None) match {
+             case x: String => x
+             case _ => ""
+           })
+      .set("submissionDate", fields.getOrElse("submissionDate", None) match {
+             case x: String => x
+             case _ => return None
+           })
+      .set("profileCreationDate", (profile \ "creationDate").asInstanceOf[Long])
+      .set("syncConfigured", weaveConfigured match {
+             case Some(x) => x
+             case _ => return None
+           })
+      // TODO
+//      .set("syncCountDesktop", weaveDesktop match {
+//             case Some(x) => x
+//             case _ => return None
+//           })
+//      .set("syncCountMobile", weaveMobile match {
+//             case Some(x) => x
+//             case _ => return None
+//           })
+      .build
+
+    Some(root)
+  }
+}

--- a/src/test/scala/ChurnTest.scala
+++ b/src/test/scala/ChurnTest.scala
@@ -1,0 +1,115 @@
+package telemetry.test
+
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
+import org.scalatest.{FlatSpec, Matchers}
+import telemetry.streams.Churn
+
+class ChurnTest extends FlatSpec with Matchers{
+  val testHistogram = """
+{
+ "payload": {
+  "histograms": {
+   "TEST_BOOLEAN_1": {
+    "sum_squares_hi": 0,
+    "values": {
+      "1": 1,
+      "0": 0
+    },
+    "histogram_type": 2,
+    "bucket_count": 3,
+    "sum_squares_lo": 0,
+    "range": [1, 2],
+    "sum": 1
+   },
+   "TEST_BOOLEAN_2": {
+    "sum_squares_hi": 0,
+    "values": {
+      "1": 0,
+      "0": 1
+    },
+    "histogram_type": 2,
+    "bucket_count": 3,
+    "sum_squares_lo": 0,
+    "range": [1, 2],
+    "sum": 0
+   },
+   "TEST_BOOLEAN_3": {
+    "sum_squares_hi": 0,
+    "values": {
+      "1": 0,
+      "0": 0
+    },
+    "histogram_type": 2,
+    "bucket_count": 3,
+    "sum_squares_lo": 0,
+    "range": [1, 2],
+    "sum": 0
+   },
+   "TEST_ENUM_1": {
+    "sum_squares_hi": 0,
+    "values": {
+      "1": 21,
+      "0": 0,
+      "2": 0
+    },
+    "histogram_type": 1,
+    "bucket_co\nunt": 9,
+    "sum_squares_lo": 21,
+    "range": [1, 8],
+    "sum": 21
+   },
+   "TEST_ENUM_2": {
+    "sum_squares_hi": 0,
+    "values": {
+      "42": 1,
+      "47": 8,
+      "48": 0,
+      "36": 3,
+      "100": 3,
+      "35": 0
+    },
+    "hist\nogram_type": 1,
+    "bucket_count": 101,
+    "sum_squares_lo": 23324,
+    "range": [1, 100],
+    "sum": 627
+   }
+  }
+ }
+}
+"""
+  "A boolean histogram" can "be converted to a boolean" in {
+    val churn = Churn("telemetry/4/main/Firefox")
+    val json = parse(testHistogram)
+    val histograms = json \ "payload" \ "histograms"
+    
+//    println("root:")
+//    println(compact(render(json)))
+//    println("---------")
+//    println("payload:")
+//    println(compact(render(json \ "payload")))
+//    println("---------")
+//    println("histograms:")
+//    println(compact(render(histograms)))
+//    println("---------")
+//    println("tb1:")
+//    println(compact(render(histograms \ "TEST_BOOLEAN_1")))
+//    println("---------")
+    
+    churn.booleanHistogramToBoolean(histograms \ "TEST_BOOLEAN_1").get should be (true)
+    churn.booleanHistogramToBoolean(histograms \ "TEST_BOOLEAN_2").get should be (false)
+    churn.booleanHistogramToBoolean(histograms \ "TEST_BOOLEAN_3") should be (None)
+    churn.booleanHistogramToBoolean(histograms \ "NO_SUCH_HISTOGRAM") should be (None)
+  }
+
+  "An enum histogram" can "be converted to a number" in {
+    val churn = Churn("telemetry/4/main/Firefox")
+    val json = parse(testHistogram)
+    val histograms = json \ "payload" \ "histograms"
+    
+    churn.enumHistogramToCount(histograms \ "TEST_ENUM_1").get should be (1)
+    churn.enumHistogramToCount(histograms \ "TEST_ENUM_2").get should be (100)
+    churn.enumHistogramToCount(histograms \ "NO_SUCH_HISTOGRAM") should be (None)
+  }
+}

--- a/src/test/scala/ChurnTest.scala
+++ b/src/test/scala/ChurnTest.scala
@@ -80,22 +80,9 @@ class ChurnTest extends FlatSpec with Matchers{
 }
 """
   "A boolean histogram" can "be converted to a boolean" in {
-    val churn = Churn("telemetry/4/main/Firefox")
+    val churn = Churn("")
     val json = parse(testHistogram)
     val histograms = json \ "payload" \ "histograms"
-    
-//    println("root:")
-//    println(compact(render(json)))
-//    println("---------")
-//    println("payload:")
-//    println(compact(render(json \ "payload")))
-//    println("---------")
-//    println("histograms:")
-//    println(compact(render(histograms)))
-//    println("---------")
-//    println("tb1:")
-//    println(compact(render(histograms \ "TEST_BOOLEAN_1")))
-//    println("---------")
     
     churn.booleanHistogramToBoolean(histograms \ "TEST_BOOLEAN_1").get should be (true)
     churn.booleanHistogramToBoolean(histograms \ "TEST_BOOLEAN_2").get should be (false)
@@ -104,7 +91,7 @@ class ChurnTest extends FlatSpec with Matchers{
   }
 
   "An enum histogram" can "be converted to a number" in {
-    val churn = Churn("telemetry/4/main/Firefox")
+    val churn = Churn("")
     val json = parse(testHistogram)
     val histograms = json \ "payload" \ "histograms"
     

--- a/src/test/scala/ParquetFile.scala
+++ b/src/test/scala/ParquetFile.scala
@@ -87,6 +87,6 @@ class ParquetSpec extends FlatSpec with Matchers{
     val jsonBlobs = HekaFrame.payloads(messages.toList)
     val data = readData(jsonBlobs, Resources.schema)
     val filename = ParquetFile.serialize(data.toIterator, Resources.schema)
-    data should be (ParquetFile.deserialize(filename))
+    data should be (ParquetFile.deserialize(filename.getName()))
   }
 }


### PR DESCRIPTION
**DO NOT MERGE**

Just looking for feedback.  I set the output bucket in `src/main/resources/application.conf` to `telemetry-test-bucket`, and I am seeing the following error when I run this code:

```
<...snip...>
16/01/08 17:19:34 INFO ShuffleBlockFetcherIterator: Started 0 remote fetches in 0 ms
16/01/08 17:19:37 INFO Executor: Finished task 35.0 in stage 4.0 (TID 47). 1165 bytes result sent to driver
16/01/08 17:19:37 INFO TaskSetManager: Starting task 40.0 in stage 4.0 (TID 52, localhost, PROCESS_LOCAL, 2170 bytes)
16/01/08 17:19:37 INFO Executor: Running task 40.0 in stage 4.0 (TID 52)
16/01/08 17:19:37 INFO TaskSetManager: Finished task 35.0 in stage 4.0 (TID 47) in 24141 ms on localhost (37/41)
16/01/08 17:19:37 INFO ShuffleBlockFetcherIterator: Getting 4 non-empty blocks out of 4 blocks
16/01/08 17:19:37 INFO ShuffleBlockFetcherIterator: Started 0 remote fetches in 0 ms
16/01/08 17:19:40 INFO Executor: Finished task 40.0 in stage 4.0 (TID 52). 1165 bytes result sent to driver
16/01/08 17:19:40 INFO TaskSetManager: Finished task 40.0 in stage 4.0 (TID 52) in 3725 ms on localhost (38/41)
16/01/08 17:19:49 INFO Executor: Finished task 38.0 in stage 4.0 (TID 50). 1165 bytes result sent to driver
16/01/08 17:19:49 INFO TaskSetManager: Finished task 38.0 in stage 4.0 (TID 50) in 19835 ms on localhost (39/41)
16/01/08 17:19:54 INFO Executor: Finished task 39.0 in stage 4.0 (TID 51). 1165 bytes result sent to driver
16/01/08 17:19:54 INFO TaskSetManager: Finished task 39.0 in stage 4.0 (TID 51) in 20263 ms on localhost (40/41)
^R
16/01/08 17:20:04 INFO Executor: Finished task 36.0 in stage 4.0 (TID 48). 1165 bytes result sent to driver
16/01/08 17:20:04 INFO TaskSetManager: Finished task 36.0 in stage 4.0 (TID 48) in 48467 ms on localhost (41/41)
16/01/08 17:20:04 INFO DAGScheduler: ResultStage 4 (foreach at SimpleDerivedStream.scala:34) finished in 123.510 s
16/01/08 17:20:04 INFO TaskSchedulerImpl: Removed TaskSet 4.0, whose tasks have all completed, from pool
16/01/08 17:20:04 INFO DAGScheduler: Job 1 finished: foreach at SimpleDerivedStream.scala:34, took 125.296149 s
16/01/08 17:20:04 ERROR ContextCleaner: Error in cleaning thread
java.lang.InterruptedException
	at java.lang.Object.wait(Native Method)
	at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:135)
	at org.apache.spark.ContextCleaner$$anonfun$org$apache$spark$ContextCleaner$$keepCleaning$1.apply$mcV$sp(ContextCleaner.scala:157)
	at org.apache.spark.util.Utils$.tryOrStopSparkContext(Utils.scala:1136)
	at org.apache.spark.ContextCleaner.org$apache$spark$ContextCleaner$$keepCleaning(ContextCleaner.scala:154)
	at org.apache.spark.ContextCleaner$$anon$3.run(ContextCleaner.scala:67)
16/01/08 17:20:04 ERROR Utils: uncaught error in thread SparkListenerBus, stopping SparkContext
java.lang.InterruptedException
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedInterruptibly(AbstractQueuedSynchronizer.java:996)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1303)
	at java.util.concurrent.Semaphore.acquire(Semaphore.java:317)
	at org.apache.spark.util.AsynchronousListenerBus$$anon$1$$anonfun$run$1.apply$mcV$sp(AsynchronousListenerBus.scala:65)
	at org.apache.spark.util.Utils$.tryOrStopSparkContext(Utils.scala:1136)
	at org.apache.spark.util.AsynchronousListenerBus$$anon$1.run(AsynchronousListenerBus.scala:63)
16/01/08 17:20:05 INFO BlockManagerInfo: Removed broadcast_3_piece0 on localhost:61555 in memory (size: 35.0 KB, free: 530.2 MB)
16/01/08 17:20:05 INFO ContextCleaner: Cleaned accumulator 4
16/01/08 17:20:05 INFO BlockManagerInfo: Removed broadcast_2_piece0 on localhost:61555 in memory (size: 36.7 KB, free: 530.2 MB)
16/01/08 17:20:05 INFO ContextCleaner: Cleaned accumulator 3
16/01/08 17:20:05 INFO ContextCleaner: Cleaned shuffle 1
16/01/08 17:20:05 INFO BlockManagerInfo: Removed broadcast_1_piece0 on localhost:61555 in memory (size: 36.5 KB, free: 530.2 MB)
16/01/08 17:20:05 INFO ContextCleaner: Cleaned accumulator 2
16/01/08 17:20:05 INFO BlockManagerInfo: Removed broadcast_0_piece0 on localhost:61555 in memory (size: 35.8 KB, free: 530.3 MB)
16/01/08 17:20:05 INFO ContextCleaner: Cleaned accumulator 1
16/01/08 17:20:05 INFO ContextCleaner: Cleaned shuffle 0
16/01/08 17:20:05 INFO SparkUI: Stopped Spark web UI at http://192.168.2.12:4040
16/01/08 17:20:05 INFO DAGScheduler: Stopping DAGScheduler
[success] Total time: 150 s, completed 8-Jan-2016 5:20:05 PM
16/01/08 17:20:05 INFO DiskBlockManager: Shutdown hook called
16/01/08 17:20:05 INFO ShutdownHookManager: Shutdown hook called
16/01/08 17:20:05 INFO ShutdownHookManager: Deleting directory /private/var/folders/11/11jyx2zd2k75487c1y762hwr0000gn/T/spark-522d2ca9-f1a0-4f8a-a428-2b87e69d0280/userFiles-e835b8ed-9b30-4e39-82fc-3ddf8c514c3d
16/01/08 17:20:05 INFO ShutdownHookManager: Deleting directory /private/var/folders/11/11jyx2zd2k75487c1y762hwr0000gn/T/spark-522d2ca9-f1a0-4f8a-a428-2b87e69d0280
```

I don't see anything appear in the output bucket, any suggestions?