### PR TITLE
Get the file path as a string correctly.

### DIFF
--- a/src/test/scala/ParquetFile.scala
+++ b/src/test/scala/ParquetFile.scala
@@ -86,7 +86,7 @@ class ParquetSpec extends FlatSpec with Matchers{
     val messages = HekaFrame.parse(new ByteArrayInputStream(Resources.hekaFile(nMessages)))
     val jsonBlobs = HekaFrame.payloads(messages.toList)
     val data = readData(jsonBlobs, Resources.schema)
-    val filename = ParquetFile.serialize(data.toIterator, Resources.schema)
-    data should be (ParquetFile.deserialize(filename.getName()))
+    val filePath = ParquetFile.serialize(data.toIterator, Resources.schema)
+    data should be (ParquetFile.deserialize(filePath.toString()))
   }
 }


### PR DESCRIPTION
Quick fix to un-break the ParquetFile tests.

The getName function just returns the basename, while toString
returns a useful path.