### PR TITLE
Modify Churn to use fewer partitions

### DIFF
--- a/src/main/scala/DerivedStream.scala
+++ b/src/main/scala/DerivedStream.scala
@@ -24,19 +24,19 @@ case class ObjectSummary(key: String, size: Long) // S3ObjectSummary can't be se
 abstract class DerivedStream extends java.io.Serializable{
   private val appConf = ConfigFactory.load()
   private val parquetBucket = Bucket(appConf.getString("app.parquetBucket"))
-  private val metadataBucket = Bucket("net-mozaws-prod-us-west-2-pipeline-metadata")
-  protected val metadataSources = {
-    val Some(sourcesObj) = metadataBucket.get(s"sources.json")
+  private val metaBucket = Bucket("net-mozaws-prod-us-west-2-pipeline-metadata")
+  protected val metaSources = {
+    val Some(sourcesObj) = metaBucket.get(s"sources.json")
     parse(Source.fromInputStream(sourcesObj.getObjectContent()).getLines().mkString("\n"))
   }
   private val metaPrefix = {
-    val JString(metaPrefix) = metadataSources \\ streamName \\ "metadata_prefix"
+    val JString(metaPrefix) = metaSources \\ streamName \\ "metadata_prefix"
     metaPrefix
   }
 
   protected val clsName = DerivedStream.uncamelize(this.getClass.getSimpleName.replace("$", ""))  // Use classname as stream prefix on S3
   protected val partitioning = {
-    val Some(schemaObj) = metadataBucket.get(s"$metaPrefix/schema.json")
+    val Some(schemaObj) = metaBucket.get(s"$metaPrefix/schema.json")
     val schema = Source.fromInputStream(schemaObj.getObjectContent()).getLines().mkString("\n")
     Partitioning(schema)
   }

--- a/src/main/scala/DerivedStream.scala
+++ b/src/main/scala/DerivedStream.scala
@@ -121,7 +121,7 @@ object DerivedStream {
     val sc = new SparkContext(conf)
     println("Spark parallelism level: " + sc.defaultParallelism)
 
-    val summaries = sc.parallelize(0 until daysCount + 1)
+    val summaries = sc.parallelize(0 to daysCount)
       .map(fromDate.plusDays(_).toString("yyyyMMdd"))
       .flatMap(date => {
                  s3.objectSummaries(bucket, s"$prefix/$date/$filterPrefix")

--- a/src/main/scala/streams/Churn.scala
+++ b/src/main/scala/streams/Churn.scala
@@ -1,5 +1,6 @@
 package telemetry.streams
 
+import awscala.s3.Bucket
 import org.apache.avro.{Schema, SchemaBuilder}
 import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder}
 import org.apache.spark.SparkContext
@@ -8,10 +9,6 @@ import org.joda.time.Days
 import org.joda.time.format.DateTimeFormat
 import org.json4s.JsonAST.{JInt, JNothing, JObject, JString, JValue}
 import org.json4s.jackson.JsonMethods.parse
-import org.json4s.jvalue2monadic
-import org.json4s.string2JsonInput
-
-import awscala.s3.Bucket
 import telemetry.{DerivedStream, ObjectSummary}
 import telemetry.DerivedStream.s3
 import telemetry.heka.{HekaFrame, Message}

--- a/src/main/scala/streams/Churn.scala
+++ b/src/main/scala/streams/Churn.scala
@@ -1,19 +1,20 @@
 package telemetry.streams
 
-import awscala._
-import awscala.s3._
-import org.joda.time.{Days, DateTime}
-import org.joda.time.format.DateTimeFormat
-import org.apache.spark.{SparkContext, Partitioner}
-import org.apache.spark.rdd.RDD
 import org.apache.avro.{Schema, SchemaBuilder}
 import org.apache.avro.generic.{GenericRecord, GenericRecordBuilder}
-import org.json4s.jackson.JsonMethods._
-import scala.collection.JavaConverters._
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.joda.time.Days
+import org.joda.time.format.DateTimeFormat
+import org.json4s.JsonAST.{JInt, JNothing, JObject, JString, JValue}
+import org.json4s.jackson.JsonMethods.parse
+import org.json4s.jvalue2monadic
+import org.json4s.string2JsonInput
+
+import awscala.s3.Bucket
 import telemetry.{DerivedStream, ObjectSummary}
 import telemetry.DerivedStream.s3
 import telemetry.heka.{HekaFrame, Message}
-import org.json4s.JsonAST.{JValue, JNothing, JInt, JObject, JString}
 import telemetry.parquet.ParquetFile
 
 case class Churn(prefix: String) extends DerivedStream{
@@ -81,11 +82,11 @@ case class Churn(prefix: String) extends DerivedStream{
     val toDate = formatter.parseDateTime(to)
     val daysCount = Days.daysBetween(fromDate, toDate).getDays()
     val bucket = {
-      val JString(bucketName) = metadataSources \\ streamName \\ "bucket"
+      val JString(bucketName) = metaSources \\ streamName \\ "bucket"
       Bucket(bucketName)
     }
     val prefix = {
-      val JString(prefix) = metadataSources \\ streamName \\ "prefix"
+      val JString(prefix) = metaSources \\ streamName \\ "prefix"
       prefix
     }
 

--- a/src/main/scala/streams/Churn.scala
+++ b/src/main/scala/streams/Churn.scala
@@ -100,7 +100,7 @@ case class Churn(prefix: String) extends DerivedStream{
       val churnMessages = sc.parallelize(groups, groups.size)
         .flatMap(x => x)
         .flatMap{ case obj =>
-          val hekaFile = bucket.getObject(obj.key).getOrElse(throw new Exception("File missing on S3"))
+          val hekaFile = bucket.getObject(obj.key).getOrElse(throw new Exception("File missing on S3: " + obj.key))
           for (message <- HekaFrame.parse(hekaFile.getObjectContent(), hekaFile.getKey()))  yield message }
         .map{ case message => messageToMap(message) }
         .repartition(100) // TODO: partition by sampleId


### PR DESCRIPTION
Instead of extending `SimpleDerivedStream`, directly extend `DerivedStream`, and ignore the supplied list of S3 objects, instead fetching the file list for each day in the specified range.

Also repartition into 100 pieces to avoid huge numbers of tiny files on S3 which causes bad performance.

There are a few ugly hacks in here (including the hard-coding of `100` as the number of partitions). Feedback welcome.