### PR TITLE
Include version in assembly jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,5 @@ sbt assembly
 ```
 then, submit the job with:
 ```
-spark-submit --master yarn-client --class telemetry.DerivedStream target/scala-2.10/telemetry-batch-view.jar --from-date 20151028 --to-date 20151028 MyStream
+spark-submit --master yarn-client --class telemetry.DerivedStream target/scala-2.10/telemetry-batch-view-X.Y.jar --from-date 20151028 --to-date 20151028 MyStream
 ``` 

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val root = (project in file(".")).
   )
 
 run in Compile <<= Defaults.runTask(fullClasspath in Compile, mainClass in (Compile, run), runner in (Compile, run))
-assemblyJarName in assembly := "telemetry-batch-view.jar"
+assemblyJarName in assembly := s"telemetry-batch-view-${version.value}.jar"
 test in assembly := {}
 
 mergeStrategy in assembly := {


### PR DESCRIPTION
This changes the assembly jar filename from `telemetry-batch-view.jar` to `telemetry-batch-view-1.0.jar` (and will change when we bump the version in `build.sbt`).